### PR TITLE
Olympus 5L128 and vermon LA/20/180 probes added to dictionary.

### DIFF
--- a/arrus/core/io/test-data/dictionary.prototxt
+++ b/arrus/core/io/test-data/dictionary.prototxt
@@ -388,6 +388,22 @@ probe_to_adapter_connections: [
             begin: 0
             end: 128
         }
-    }
+    },
+    {
+        probe_model_id: {
+            manufacturer: "vermon"
+            name: "la/20/128"
+        }
+        probe_adapter_model_id: [
+            {
+                manufacturer: "us4us"
+                name: "atl/philips"
+            }
+        ]
+        channel_mapping_ranges: {
+            begin: 0
+            end: 128
+        }
+    }    
    
 ]

--- a/arrus/core/io/test-data/dictionary.prototxt
+++ b/arrus/core/io/test-data/dictionary.prototxt
@@ -254,7 +254,40 @@ probe_models: [
 			begin: 0,
 			end: 75
 		}
-    }
+    },
+    
+    {
+        id: {
+            manufacturer: "olympus"
+            name: "5L128"
+        }
+        n_elements: 128,
+        pitch: 0.6e-3,
+        tx_frequency_range: {
+            begin: 1e6,
+            end: 10e6
+        },
+        voltage_range: {
+			begin: 0,
+			end: 115
+		}
+    },
+    {
+        id: {
+            manufacturer: "vermon"
+            name: "la/20/128"
+        }
+        n_elements: 128,
+        pitch: 0.1e-3,
+        tx_frequency_range: {
+            begin: 10e6,
+            end: 30e6
+        },
+        voltage_range: {
+			begin: 0,
+			end: 15
+		}
+    }    
 ]
 
 probe_to_adapter_connections: [
@@ -339,5 +372,22 @@ probe_to_adapter_connections: [
                 begin: 0
                 end: 128
          }
-     }
+     },
+    {
+        probe_model_id: {
+            manufacturer: "olympus"
+            name: "5L128"
+        }
+        probe_adapter_model_id: [
+            {
+                manufacturer: "us4us"
+                name: "esaote3"
+            }
+        ]
+        channel_mapping_ranges: {
+            begin: 0
+            end: 128
+        }
+    }
+   
 ]


### PR DESCRIPTION
According to data sheet HV for olympus probe is up to 180V for frequencies < 7.5MHz, and 115V for frequencies >10MHz. For safety reasons max voltage is now set to 115 V (for all frequencies).
HV for vermon probe is up to 30V (60Vpp according to data sheet). For safety reasons max voltage is now set to 15V.
Adapter for vermon probe (ATL/Philips) is not defined yet!