### PR TITLE
#US4R-129: Made Us4R::stop synchronous. 

### DIFF
--- a/api/python/arrus/session.py
+++ b/api/python/arrus/session.py
@@ -195,9 +195,7 @@ class Session(AbstractSession):
         """
         Stops execution of the scheme.
         """
-        _STOP_TIME = 2
         arrus.core.arrusSessionStopScheme(self._session_handle)
-        time.sleep(_STOP_TIME)
         if self._current_processing is not None:
             self._current_processing.stop()
 

--- a/arrus/core/devices/us4r/Us4RImpl.cpp
+++ b/arrus/core/devices/us4r/Us4RImpl.cpp
@@ -175,7 +175,6 @@ void Us4RImpl::stopDevice() {
         logger->log(LogSeverity::DEBUG, "Stopping system.");
         this->getDefaultComponent()->stop();
         for(auto &us4oem: us4oems) {
-            std::cout << "Waiting for pending interrupts" << std::endl;
             us4oem->getIUs4oem()->WaitForPendingTransfers();
             us4oem->getIUs4oem()->WaitForPendingInterrupts();
         }


### PR DESCRIPTION
After calling Us4R::stop method no new interrupts should be raised. The solution reduces the time needed to stop us4R device programmatically.