### PR TITLE
#ARRUS-189: Exposed us4OEM FPGA and UCD temperature in Python and C++ API

### DIFF
--- a/api/python/arrus/devices/us4oem.py
+++ b/api/python/arrus/devices/us4oem.py
@@ -1,5 +1,6 @@
 import ctypes
 from arrus.devices.device import Device, DeviceId, DeviceType
+import arrus.core
 
 DEVICE_TYPE = DeviceType("Us4OEM")
 
@@ -15,7 +16,31 @@ class Us4OEM(Device):
         return self._device_id
 
     def get_firmware_version(self) -> int:
+        """
+        Returns us4OEM's main firmware version.
+        """
         return ctypes.c_ulong(self._handle.getFirmwareVersion()).value
 
     def get_tx_firmware_version(self) -> int:
+        """
+        Returns TX Firmware version.
+        """
         return ctypes.c_ulong(self._handle.getTxFirmwareVersion()).value
+
+    def get_fpga_temperature(self) -> float:
+        """
+        Returns Us4OEM FPGA temperature [Celsius]
+        """
+        return arrus.core.arrusUs4OEMGetFPGATemperature(self._handle)
+
+    def get_ucd_temperature(self) -> float:
+        """
+        Returns Us4OEM UCD temperature [Celsius]
+        """
+        return arrus.core.arrusUs4OEMGetUCDTemperature(self._handle)
+
+    def get_ucd_external_temperature(self) -> float:
+        """
+        Returns Us4OEM UCD external temperature [Celsius]
+        """
+        return arrus.core.arrusUs4OEMGetUCDExternalTemperature(self._handle)

--- a/api/python/wrappers/core.i
+++ b/api/python/wrappers/core.i
@@ -334,6 +334,23 @@ double getPitch(const arrus::devices::ProbeModel &probe) {
     }
     return pitch[0];
 }
+// GIL free methods
+
+float arrusUs4OEMGetFPGATemperature(::arrus::devices::Us4OEM *us4oem) {
+    ArrusPythonGILUnlock unlock;
+    return us4oem->getFPGATemperature();
+}
+
+float arrusUs4OEMGetUCDTemperature(::arrus::devices::Us4OEM *us4oem) {
+    ArrusPythonGILUnlock unlock;
+    return us4oem->getUCDTemperature();
+}
+
+float arrusUs4OEMGetUCDExternalTemperature(::arrus::devices::Us4OEM *us4oem) {
+    ArrusPythonGILUnlock unlock;
+    return us4oem->getUCDExternalTemperature();
+}
+
 %};
 
 // ------------------------------------------ OPERATIONS

--- a/arrus/core/api/devices/us4r/Us4OEM.h
+++ b/arrus/core/api/devices/us4r/Us4OEM.h
@@ -40,6 +40,16 @@ public:
     virtual float getFPGATemperature() = 0;
 
     /**
+     * Returns temperature measured by Us4OEM's UCD [Celsius]
+     */
+    virtual float getUCDTemperature() = 0;
+
+    /**
+     * Returns external temperature measured by Us4OEM's UCD [Celsius]
+     */
+    virtual float getUCDExternalTemperature() = 0;
+
+    /**
      * Returns rail voltage measured by Us4OEM's UCD [V].
      *
      * @param rail UCD rail number

--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
@@ -118,6 +118,8 @@ public:
     MOCK_METHOD(float, getFPGAWallclock, (), (override));
     MOCK_METHOD(void, setHpfCornerFrequency, (uint32_t), (override));
     MOCK_METHOD(void, disableHpf, (), (override));
+    MOCK_METHOD(float, getUCDTemperature, (), (override));
+    MOCK_METHOD(float, getUCDExternalTemperature, (), (override));
 };
 
 class AbstractProbeAdapterImplTest : public ::testing::Test {

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -712,6 +712,10 @@ inline void Us4OEMImpl::setActiveTerminationAfe(std::optional<uint16> param, boo
 
 float Us4OEMImpl::getFPGATemperature() { return ius4oem->GetFPGATemp(); }
 
+float Us4OEMImpl::getUCDTemperature() { return ius4oem->GetUCDTemp(); }
+
+float Us4OEMImpl::getUCDExternalTemperature() { return ius4oem->GetUCDExtTemp(); }
+
 float Us4OEMImpl::getUCDMeasuredVoltage(uint8_t rail) { return ius4oem->GetUCDVOUT(rail); }
 
 void Us4OEMImpl::checkFirmwareVersion() {

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
@@ -123,6 +123,8 @@ public:
     std::vector<uint8_t> getChannelMapping() override;
     void setRxSettings(const RxSettings &newSettings) override;
     float getFPGATemperature() override;
+    float getUCDTemperature() override;
+    float getUCDExternalTemperature() override;
     float getUCDMeasuredVoltage(uint8_t rail) override;
     void checkFirmwareVersion() override;
     uint32 getFirmwareVersion() override;

--- a/docs/content/api.python.rst
+++ b/docs/content/api.python.rst
@@ -82,6 +82,10 @@ Devices
     :exclude-members: start, stop, get_probe_model
     :show-inheritance:
 
+.. autoclass:: arrus.devices.us4oem.Us4OEM
+    :members:
+    :show-inheritance:
+
 .. autoclass:: arrus.devices.gpu.GPU
     :show-inheritance:
 

--- a/docs/content/misc/release_notes.rst
+++ b/docs/content/misc/release_notes.rst
@@ -17,6 +17,7 @@ Release notes
 
 - Python API:
 
+    - Exposed Us4OEM FPGA, UCD, UCD external temperature.
     - Implemented new module `arrus.utils.probe_check` for probe checking and automatic channel health, see example: examples/check_probe.py
     - exposed hardware Digital Down Conversion
     - us4R: exposed the possibility to change hardware high-pass filter cutoff frequency


### PR DESCRIPTION
Exposed in Python API: arrus.devices.us4oem.Us4OEM.{get_fpga_temperature, get_ucd_temperature, get_ucd_external_temperature}