### PR TITLE
#ARRUS-200, ARRUS-201: Enable the linearizing curve for the TGC for LNA, PGA other than 24, 30, exposed TGC curve, LNA, PGA setters in MATLAB API.

### DIFF
--- a/api/matlab/+arrus/+devices/+us4r/Us4R.m
+++ b/api/matlab/+arrus/+devices/+us4r/Us4R.m
@@ -54,5 +54,35 @@ classdef Us4R < handle
             res = obj.ptr.callMethod("getChannelsMask", 1);
             channelsMask = res{1, 1};
         end
+
+        function setTgcCurve(varargin)
+            %
+            % Sets TGC curve points asynchronously.
+            % Setting empty vectors t and y turns off analog TGC. Setting non-empty vector turns off DTGC
+            %  and turns on analog TGC.
+            % Vectors t and y should have exactly the same size. The input t and y values will be interpolated
+            % into target hardware sampling points (according to getCurrentSamplingFrequency and getCurrentTgcPoints).
+            % Linear interpolation will be performed, the TGC curve will be extrapolated with the first
+            % (left-side of the cure) and the last sample (right side of the curve).
+            %
+            % :param time: sampling time, relative to the "sample 0" (optional, hardware sampling time will be used
+            % if not provided)
+            % :param value: values to apply at given sampling time
+            % :param applyCharacteristic: set it to true if you want to compensate response characteristic
+            % (pre-computed by us4us).
+            obj = varargin{1};
+            if nargin == 4
+                time = varargin{2};
+                value = varargin{3};
+                applyCharacteristic = varargin{4};
+                obj.ptr.callMethod("setTgcCurveTimeValue", 0, time, value, logical(applyCharacteristic));
+            elseif nargin == 3
+                value = varargin{2};
+                applyCharacteristic = varargin{3};
+                obj.ptr.callMethod("setTgcCurveValue", 0, value, logical(applyCharacteristic));
+            else
+                error("Unsupported number of parameters.");
+            end
+        end
     end
 end

--- a/api/matlab/+arrus/+devices/+us4r/Us4R.m
+++ b/api/matlab/+arrus/+devices/+us4r/Us4R.m
@@ -101,5 +101,22 @@ classdef Us4R < handle
             % :param gain: gain value to set [dB]
             obj.ptr.callMethod("setLnaGain", 0, gain);
         end
+
+        function [gain] = getPgaGain(obj)
+            %
+            % Returns current PGA gain value.
+            %
+            % :return: PGA gain value [dB]
+            res = obj.ptr.callMethod("getPgaGain", 1);
+            gain = res{1, 1};
+        end
+
+        function setPgaGain(obj, gain)
+            %
+            % Sets the PGA gain to the given value.
+            %
+            % :param gain: gain value to set [dB]
+            obj.ptr.callMethod("setPgaGain", 0, gain);
+        end
     end
 end

--- a/api/matlab/+arrus/+devices/+us4r/Us4R.m
+++ b/api/matlab/+arrus/+devices/+us4r/Us4R.m
@@ -84,5 +84,22 @@ classdef Us4R < handle
                 error("Unsupported number of parameters.");
             end
         end
+
+        function [gain] = getLnaGain(obj)
+            %
+            % Returns current LNA gain value.
+            %
+            % :return: LNA gain value [dB]
+            res = obj.ptr.callMethod("getLnaGain", 1);
+            gain = res{1, 1};
+        end
+
+        function setLnaGain(obj, gain)
+            %
+            % Sets the LNA gain to the given value.
+            %
+            % :param gain: gain value to set [dB]
+            obj.ptr.callMethod("setLnaGain", 0, gain);
+        end
     end
 end

--- a/api/matlab/arrus/Us4R.m
+++ b/api/matlab/arrus/Us4R.m
@@ -103,6 +103,11 @@ classdef Us4R < handle
             nProbeElem = obj.sys.nElem;
         end
 
+        function setTgcCurve(varargin)
+            obj = varargin{1};
+            obj.us4r.setTgcCurve(varargin{2:end});
+        end
+
         function upload(obj, sequenceOperation, reconstructOperation, enableHardwareProgramming)
             % Uploads operations to the us4R system.
             %

--- a/api/matlab/arrus/Us4R.m
+++ b/api/matlab/arrus/Us4R.m
@@ -103,6 +103,14 @@ classdef Us4R < handle
             nProbeElem = obj.sys.nElem;
         end
 
+        function setLnaGain(obj,gain)
+            obj.us4r.setLnaGain(gain);
+        end
+
+        function setPgaGain(obj,gain)
+            obj.us4r.setPgaGain(gain);
+        end
+
         function setTgcCurve(varargin)
             obj = varargin{1};
             obj.us4r.setTgcCurve(varargin{2:end});

--- a/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
+++ b/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
@@ -29,6 +29,8 @@ public:
         ARRUS_MATLAB_ADD_METHOD("getSamplingFrequency", getSamplingFrequency);
         ARRUS_MATLAB_ADD_METHOD("getProbeModel", getProbeModel);
         ARRUS_MATLAB_ADD_METHOD("getChannelsMask", getChannelsMask);
+        ARRUS_MATLAB_ADD_METHOD("setTgcCurveValue", setTgcCurveValue);
+        ARRUS_MATLAB_ADD_METHOD("setTgcCurveTimeValue", setTgcCurveTimeValue);
     }
 
     void disableHV(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
@@ -55,6 +57,26 @@ public:
     void getChannelsMask(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
         auto channelsMask = get(obj)->getChannelsMask();
         outputs[0] = ARRUS_MATLAB_GET_MATLAB_VECTOR(ctx, unsigned short, channelsMask);
+    }
+
+    void setTgcCurveValue(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        std::vector<float> value = convertToCppVector<float>(inputs[0], "tgc values");
+        bool applyCharacteristic = inputs[1][0];
+        ctx->logInfo(format("Us4R: setting TGC curve, value {}, apply characteristic {}",
+                            fmt::join(value, ", "),
+                            applyCharacteristic));
+        get(obj)->setTgcCurve(value, applyCharacteristic);
+    }
+
+    void setTgcCurveTimeValue(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        std::vector<float> time = convertToCppVector<float>(inputs[0], "tgc time");
+        std::vector<float> value = convertToCppVector<float>(inputs[1], "tgc values");
+        bool applyCharacteristic = inputs[2][0];
+        ctx->logInfo(format("Us4R: setting TGC curve time {}, value {}, apply characteristic {}",
+                            fmt::join(time, ", "),
+                            fmt::join(value, ", "),
+                            applyCharacteristic));
+        get(obj)->setTgcCurve(time, value, applyCharacteristic);
     }
 
 };

--- a/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
+++ b/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
@@ -31,6 +31,8 @@ public:
         ARRUS_MATLAB_ADD_METHOD("getChannelsMask", getChannelsMask);
         ARRUS_MATLAB_ADD_METHOD("setTgcCurveValue", setTgcCurveValue);
         ARRUS_MATLAB_ADD_METHOD("setTgcCurveTimeValue", setTgcCurveTimeValue);
+        ARRUS_MATLAB_ADD_METHOD("setLnaGain", setLnaGain);
+        ARRUS_MATLAB_ADD_METHOD("getLnaGain", getLnaGain);
     }
 
     void disableHV(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
@@ -77,6 +79,16 @@ public:
                             fmt::join(value, ", "),
                             applyCharacteristic));
         get(obj)->setTgcCurve(time, value, applyCharacteristic);
+    }
+
+    void setLnaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        uint16 gain = inputs[0][0];
+        get(obj)->setLnaGain(gain);
+    }
+
+    void getLnaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        float gain = get(obj)->getLnaGain();
+        outputs[0] = ARRUS_MATLAB_GET_MATLAB_SCALAR(ctx, uint16, gain);
     }
 
 };

--- a/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
+++ b/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
@@ -33,6 +33,8 @@ public:
         ARRUS_MATLAB_ADD_METHOD("setTgcCurveTimeValue", setTgcCurveTimeValue);
         ARRUS_MATLAB_ADD_METHOD("setLnaGain", setLnaGain);
         ARRUS_MATLAB_ADD_METHOD("getLnaGain", getLnaGain);
+        ARRUS_MATLAB_ADD_METHOD("setPgaGain", setPgaGain);
+        ARRUS_MATLAB_ADD_METHOD("getPgaGain", getPgaGain);
     }
 
     void disableHV(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
@@ -88,6 +90,16 @@ public:
 
     void getLnaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
         float gain = get(obj)->getLnaGain();
+        outputs[0] = ARRUS_MATLAB_GET_MATLAB_SCALAR(ctx, uint16, gain);
+    }
+
+    void setPgaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        uint16 gain = inputs[0][0];
+        get(obj)->setPgaGain(gain);
+    }
+
+    void getPgaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
+        float gain = get(obj)->getPgaGain();
         outputs[0] = ARRUS_MATLAB_GET_MATLAB_SCALAR(ctx, uint16, gain);
     }
 

--- a/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
+++ b/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
@@ -66,9 +66,6 @@ public:
     void setTgcCurveValue(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
         std::vector<float> value = convertToCppVector<float>(inputs[0], "tgc values");
         bool applyCharacteristic = inputs[1][0];
-        ctx->logInfo(format("Us4R: setting TGC curve, value {}, apply characteristic {}",
-                            fmt::join(value, ", "),
-                            applyCharacteristic));
         get(obj)->setTgcCurve(value, applyCharacteristic);
     }
 
@@ -76,10 +73,6 @@ public:
         std::vector<float> time = convertToCppVector<float>(inputs[0], "tgc time");
         std::vector<float> value = convertToCppVector<float>(inputs[1], "tgc values");
         bool applyCharacteristic = inputs[2][0];
-        ctx->logInfo(format("Us4R: setting TGC curve time {}, value {}, apply characteristic {}",
-                            fmt::join(time, ", "),
-                            fmt::join(value, ", "),
-                            applyCharacteristic));
         get(obj)->setTgcCurve(time, value, applyCharacteristic);
     }
 

--- a/api/python/arrus/kernels/tgc.py
+++ b/api/python/arrus/kernels/tgc.py
@@ -31,6 +31,7 @@ def compute_linear_tgc(seq_context, fs, linear_tgc):
     sampling_time = sampling_time/fs
     distance = sampling_time*c
     tgc_values = tgc_start + distance*tgc_slope
+    # TODO: the below should be moved to ARRUS CORE
     if linear_tgc.clip:
         tgc_values = np.clip(tgc_values, 14, 54)
     return sampling_time, tgc_values

--- a/arrus/core/api/devices/us4r/Us4R.h
+++ b/arrus/core/api/devices/us4r/Us4R.h
@@ -168,11 +168,25 @@ public:
     virtual void setPgaGain(uint16 value) = 0;
 
     /**
+     * Returns the current PGA gain value.
+     *
+     * See docs of arrus::devices::RxSettings for more information.
+     */
+    virtual uint16 getPgaGain() = 0;
+
+    /**
      * Sets LNA gain.
      *
      * See docs of arrus::devices::RxSettings for more information.
      */
     virtual void setLnaGain(uint16 value) = 0;
+
+    /**
+     * Returns the current LNA gain value.
+     *
+     * See docs of arrus::devices::RxSettings for more information.
+    */
+    virtual uint16 getLnaGain() = 0;
 
     /**
      * Sets LPF cutoff.

--- a/arrus/core/devices/us4r/Us4RImpl.cpp
+++ b/arrus/core/devices/us4r/Us4RImpl.cpp
@@ -409,10 +409,18 @@ void Us4RImpl::setPgaGain(uint16 value) {
     auto newRxSettings = RxSettingsBuilder(rxSettings.value()).setPgaGain(value)->build();
     setRxSettings(newRxSettings);
 }
+uint16 Us4RImpl::getPgaGain() {
+    ARRUS_ASSERT_RX_SETTINGS_SET();
+    return this->rxSettings.value().getPgaGain();
+}
 void Us4RImpl::setLnaGain(uint16 value) {
     ARRUS_ASSERT_RX_SETTINGS_SET();
     auto newRxSettings = RxSettingsBuilder(rxSettings.value()).setLnaGain(value)->build();
     setRxSettings(newRxSettings);
+}
+uint16 Us4RImpl::getLnaGain() {
+    ARRUS_ASSERT_RX_SETTINGS_SET();
+    return this->rxSettings.value().getLnaGain();
 }
 void Us4RImpl::setLpfCutoff(uint32 value) {
     ARRUS_ASSERT_RX_SETTINGS_SET();

--- a/arrus/core/devices/us4r/Us4RImpl.h
+++ b/arrus/core/devices/us4r/Us4RImpl.h
@@ -107,7 +107,9 @@ public:
 
     void setRxSettings(const RxSettings &settings) override;
     void setPgaGain(uint16 value) override;
+    uint16 getPgaGain() override;
     void setLnaGain(uint16 value) override;
+    uint16 getLnaGain() override;
     void setLpfCutoff(uint32 value) override;
     void setDtgcAttenuation(std::optional<uint16> value) override;
     void setActiveTermination(std::optional<uint16> value) override;

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -635,8 +635,6 @@ void Us4OEMImpl::setTgcCurve(const RxSettings &afeCfg) {
         for (auto &val : actualTgc) {
             val = (val - tgcMin) / TGC_ATTENUATION_RANGE;
         }
-        std::cout << std::endl;
-
         if (applyCharacteristic) {
             // TGC characteristic, experimentally verified.
             static const std::vector<float> tgcChar = {

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -658,8 +658,6 @@ void Us4OEMImpl::setTgcCurve(const RxSettings &afeCfg) {
                 0.9f  , 0.925f, 0.95f , 0.975f, 1.0f
             };
             actualTgc = ::arrus::interpolate1d(tgcChar, tgcCharPoints, actualTgc);
-        } else {
-            actualTgc = tgc;
         }
         ius4oem->TGCEnable();
         // Currently setting firing parameter has no impact on the result

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -630,23 +630,40 @@ void Us4OEMImpl::setTgcCurve(const RxSettings &afeCfg) {
     if (tgc.empty()) {
         ius4oem->TGCDisable();
     } else {
-        ius4oem->TGCEnable();
-        std::vector<float> actualTgc;
-
-        if (applyCharacteristic) {
-            static const std::vector<float> tgcChar = {
-                14.000f, 14.001f, 14.002f, 14.003f, 14.024f, 14.168f, 14.480f, 14.825f, 15.234f, 15.770f, 16.508f,
-                17.382f, 18.469f, 19.796f, 20.933f, 21.862f, 22.891f, 24.099f, 25.543f, 26.596f, 27.651f, 28.837f,
-                30.265f, 31.690f, 32.843f, 34.045f, 35.543f, 37.184f, 38.460f, 39.680f, 41.083f, 42.740f, 44.269f,
-                45.540f, 46.936f, 48.474f, 49.895f, 50.966f, 52.083f, 53.256f, 54.0f};
-            // observed -> applied (e.g. when applying 15 dB actually 14.01 gain was observed)
-            actualTgc = ::arrus::interpolate1d(tgcChar, ::arrus::getRange<float>(14, 55, 1.0), tgc);
-        } else {
-            actualTgc = tgc;
-        }
+        std::vector<float> actualTgc = tgc;
+        // Normalize to [0, 1].
         for (auto &val : actualTgc) {
             val = (val - tgcMin) / TGC_ATTENUATION_RANGE;
         }
+        std::cout << std::endl;
+
+        if (applyCharacteristic) {
+            // TGC characteristic, experimentally verified.
+            static const std::vector<float> tgcChar = {
+                0.0f, 2.4999999999986144e-05f, 5.00000000000167e-05f, 7.500000000000284e-05f,
+                0.0005999999999999784f, 0.0041999999999999815f, 0.01200000000000001f, 0.020624999999999984f,
+                0.03085f, 0.04424999999999999f, 0.06269999999999998f, 0.08455000000000004f,
+                0.11172500000000003f, 0.14489999999999997f, 0.173325f, 0.19654999999999995f,
+                0.22227499999999994f, 0.252475f, 0.28857499999999997f, 0.3149f,
+                0.341275f, 0.370925f, 0.406625f, 0.44225000000000003f,
+                0.4710750000000001f, 0.501125f, 0.538575f, 0.5795999999999999f,
+                0.6115f, 0.642f, 0.677075f, 0.7185f,
+                0.756725f, 0.7885f, 0.8234f, 0.8618499999999999f,
+                0.897375f, 0.92415f, 0.952075f, 0.9814f, 1.0f
+            };
+            // the below is simply linspace(0, 1, 41)
+            static const std::vector<float> tgcCharPoints = {
+                0.0f   , 0.025f, 0.05f, 0.075f, 0.1f, 0.125f, 0.15f, 0.175f, 0.2f  ,
+                0.225f, 0.25f , 0.275f, 0.3f  , 0.325f, 0.35f , 0.375f, 0.4f  , 0.425f,
+                0.45f , 0.475f, 0.5f  , 0.525f, 0.55f , 0.575f, 0.6f  , 0.625f, 0.65f ,
+                0.675f, 0.7f  , 0.725f, 0.75f , 0.775f, 0.8f  , 0.825f, 0.85f , 0.875f,
+                0.9f  , 0.925f, 0.95f , 0.975f, 1.0f
+            };
+            actualTgc = ::arrus::interpolate1d(tgcChar, tgcCharPoints, actualTgc);
+        } else {
+            actualTgc = tgc;
+        }
+        ius4oem->TGCEnable();
         // Currently setting firing parameter has no impact on the result
         // because TGC can be set only once for the whole sequence.
         ius4oem->TGCSetSamples(actualTgc, 0);

--- a/arrus/core/devices/us4r/validators/RxSettingsValidator.h
+++ b/arrus/core/devices/us4r/validators/RxSettingsValidator.h
@@ -36,7 +36,7 @@ public:
         if(!settings.getTgcSamples().empty()) {
             expectInRange("tgc samples", settings.getTgcSamples().size(), size_t(0), size_t(Us4OEMImpl::TGC_N_SAMPLES));
             auto[min, max] = RxSettings::getTgcMinMax(settings.getPgaGain(), settings.getLnaGain());
-            expectAllInRange("tgc samples", settings.getTgcSamples(), std::max(min, 0.0f), max);
+            expectAllInRange("tgc samples", settings.getTgcSamples(), min, max);
         }
     }
 };

--- a/arrus/core/devices/us4r/validators/RxSettingsValidator.h
+++ b/arrus/core/devices/us4r/validators/RxSettingsValidator.h
@@ -34,11 +34,6 @@ public:
                         settings.getActiveTermination().value(), ActiveTerminationValueMap::getInstance().getAvailableValues());
         }
         if(!settings.getTgcSamples().empty()) {
-            ARRUS_VALIDATOR_EXPECT_TRUE_M(
-                    !settings.isApplyTgcCharacteristic()
-                            || (settings.getPgaGain() == 30 and settings.getLnaGain() == 24),
-                    "Currently TGC characteristic can be automatically compensated only for "
-                    "PGA gain = 30 and LNA gain = 24");
             expectInRange("tgc samples", settings.getTgcSamples().size(), size_t(0), size_t(Us4OEMImpl::TGC_N_SAMPLES));
             auto[min, max] = RxSettings::getTgcMinMax(settings.getPgaGain(), settings.getLnaGain());
             expectAllInRange("tgc samples", settings.getTgcSamples(), std::max(min, 0.0f), max);


### PR DESCRIPTION
- Exposed TGC, LNA, PGA gain setters in MATLAB API
- Enabled curve linearization for all LNA and PGA gain values