### PR TITLE
#ARRUS-202, ARRUS-203: fix issue with TGC in Matlab, enable the RF display.

### DIFF
--- a/api/matlab/arrus/CustomTxRxSequence.m
+++ b/api/matlab/arrus/CustomTxRxSequence.m
@@ -56,7 +56,7 @@ classdef CustomTxRxSequence
         nRepetitions (1,:) = 1
         txPri (1,:) double {mustBePositive}
         tgcStart (1,:)
-        tgcSlope (1,:)
+        tgcSlope (1,:) = 0
         txInvert (1,:) {mustBeLogical} = false
     end
     

--- a/api/matlab/examples/Us4R_control_rawRfPwi.m
+++ b/api/matlab/examples/Us4R_control_rawRfPwi.m
@@ -1,0 +1,64 @@
+% Example script for b-mode imaging using plane waves and angular scanning
+
+%% Initialize the system
+addpath('..\');
+addpath('..\arrus');
+
+% Make sure the configuration in the *.prototxt file is correct.
+us  = Us4R('configFile', 'us4r.prototxt');
+
+%% Selected parameters
+% To program plane wave sequence, set 'txFocus' to infinity.
+txFoc = inf;                    % Focal distance [m]
+
+% To program angular scanning/compounding, set 'txAngle' as a vector. 
+% It will also determine the number of transmissions in the sequence.
+txAng = (-15:15:15)*pi/180;      % Plane wave angles [rad]
+nTx = numel(txAng);             % Number of transmissions in a sequence
+
+%% Program Tx/Rx sequence and reconstruction
+% Set the Tx/Rx sequence
+% If the sequence consists of nTx transmissions, then the following
+% parameters must be vectors of length nTx or scalars (if they are constant):
+% txApertureCenter/txCenterElement, rxApertureCenter/rxCenterElement,
+% txApertureSize, txFocus, txAngle, txFrequency, txNPeriods, txInvert.
+% All other parameters are constant for the whole sequence, thus they are scalars.
+seq = CustomTxRxSequence(... % Obligatory parameters
+                        ... % (tx/rxApertureCenter [m] can be replaced with 
+                        ... % tx/rxCenterElement [elem], rxDepthRange [m] 
+                        ... % can be replaced with rxNSamples [samp])
+                        'txApertureCenter', 0e-3, ...
+                        'txApertureSize',   us.getNProbeElem, ...
+                        'rxApertureCenter', 0e-3, ...
+                        'rxApertureSize',   us.getNProbeElem, ...
+                        'txFocus',          txFoc, ...
+                        'txAngle',          txAng, ...
+                        'speedOfSound',     1540, ...
+                        'txFrequency',      6.5e6, ...
+                        'txNPeriods',       2, ...
+                        'txVoltage',        5, ...
+                        'rxNSamples',       4*1024, ...
+                        'tgcStart',         14, ...
+                        'tgcSlope',         200, ...
+                        'hwDdcEnable',      false ... % set to false/true to obtain raw data as RF/decimated IQ
+                        );
+
+us.upload(seq);
+
+%% Preview (continuous in-loop operation)
+% Warning: the raw rf display methods (imageRawRf and plotRawRf) require
+% the rf to be real, and thus the hwDdcEnable must be set to false.
+
+% Show image of all rf echoes in the sequence
+us.imageRawRf('amplitudeLim',1e3);
+
+% Plot a selected rf line (96 = 32nd line from 2nd TX)
+us.plotRawRf('selectedLines',96);
+
+%% Collecting data (single execution of the sequence)
+[raw,img] = us.run;
+
+%% Close session
+us.closeSession;
+
+

--- a/api/matlab/examples/Us4R_control_rawRfPwi.m
+++ b/api/matlab/examples/Us4R_control_rawRfPwi.m
@@ -1,4 +1,4 @@
-% Example script for b-mode imaging using plane waves and angular scanning
+% Example script for raw rf imaging when using plane waves and angular scanning
 
 %% Initialize the system
 addpath('..\');

--- a/arrus/core/devices/us4r/Us4RImpl.cpp
+++ b/arrus/core/devices/us4r/Us4RImpl.cpp
@@ -368,8 +368,8 @@ void Us4RImpl::setTgcCurve(const std::vector<float> &t, const std::vector<float>
 std::vector<float> Us4RImpl::getTgcCurvePoints(float maxT) const {
     // TODO(jrozb91) To reconsider below.
     float nominalFs = getSamplingFrequency();
-    uint16 offset = 200;
-    uint16 tgcT = 150;
+    uint16 offset = 359;
+    uint16 tgcT = 153;
     // TODO try avoid converting from samples to time then back to samples?
     uint16 maxNSamples = int16(roundf(maxT*nominalFs));
     // Note: the last TGC sample should be applied before the reception ends.


### PR DESCRIPTION
ARRUS-202:
- TGC range is dependent on LNA and PGA values.
- TGC delay and sampling are verified and corrected.

ARRUS-203:
- RF display is now available in Matlab using plotRawRf or imageRawRf methods of the Us4R class. 
- The maximum amplitude of the undistorted* signal can be optionally marked.
* distortions due to the AFE input voltage exceeding the allowed range (nonlinear behaviour observed outside this range)