### PR TITLE
#ARRUS-237: Adress situation (in utils.imaging module), when cupy has version with letter at the end.

### DIFF
--- a/api/python/arrus/utils/imaging.py
+++ b/api/python/arrus/utils/imaging.py
@@ -38,7 +38,7 @@ if is_package_available("cupy"):
     import cupy
     import re
 
-    if not re.match("^\\d+\\.\\d+\\.\\d+[a-z]?\\d?$", cupy.__version__):
+    if not re.match("^\\d+\\.\\d+\\.\\d+[a-z]*\\d*$", cupy.__version__):
         raise ValueError(f"Unrecognized pattern "
                          f"of the cupy version: {cupy.__version__}")
     m = re.search("^\\d+\\.\\d+\\.\\d+", cupy.__version__)

--- a/api/python/arrus/utils/imaging.py
+++ b/api/python/arrus/utils/imaging.py
@@ -39,16 +39,11 @@ if is_package_available("cupy"):
     import cupy
     import re
 
-    if not hasattr(cupy, "__version__"):
-        warnings.warn(
-            "Warning, cupy package has no __version__ attribute, "
-            "could not determine cupy version. "
-            "Imaging package may not work properly."
-        )
-    elif not re.match("^\\d+\\.\\d+\\.\\d+$", cupy.__version__):
+    if not re.match("^\\d+\\.\\d+\\.\\d+[a-z]?\\d?$", cupy.__version__):
         raise ValueError(f"Unrecognized pattern "
                          f"of the cupy version: {cupy.__version__}")
-    elif tuple(int(v) for v in cupy.__version__.split(".")) < (9, 0, 0):
+    m = re.search("^\\d+\\.\\d+\\.\\d+", cupy.__version__)
+    if tuple(int(v) for v in m.group().split(".")) < (9, 0, 0):
         raise Exception(f"The version of cupy module is too low. "
                         f"Use version ''9.0.0'' or higher.")
 else:

--- a/api/python/arrus/utils/imaging.py
+++ b/api/python/arrus/utils/imaging.py
@@ -28,7 +28,6 @@ from numbers import Number
 from typing import Sequence, Dict, Callable, Union, Tuple
 from arrus.params import ParameterDef, Unit, Box
 from collections import defaultdict
-import warnings
 
 
 def is_package_available(package_name):

--- a/api/python/arrus/utils/imaging.py
+++ b/api/python/arrus/utils/imaging.py
@@ -28,6 +28,7 @@ from numbers import Number
 from typing import Sequence, Dict, Callable, Union, Tuple
 from arrus.params import ParameterDef, Unit, Box
 from collections import defaultdict
+import warnings
 
 
 def is_package_available(package_name):
@@ -38,10 +39,16 @@ if is_package_available("cupy"):
     import cupy
     import re
 
-    if not re.match("^\\d+\\.\\d+\\.\\d+$", cupy.__version__):
+    if not hasattr(cupy, "__version__"):
+        warnings.warn(
+            "Warning, cupy package has no __version__ attribute, "
+            "could not determine cupy version. "
+            "Imaging package may not work properly."
+        )
+    elif not re.match("^\\d+\\.\\d+\\.\\d+$", cupy.__version__):
         raise ValueError(f"Unrecognized pattern "
                          f"of the cupy version: {cupy.__version__}")
-    if tuple(int(v) for v in cupy.__version__.split(".")) < (9, 0, 0):
+    elif tuple(int(v) for v in cupy.__version__.split(".")) < (9, 0, 0):
         raise Exception(f"The version of cupy module is too low. "
                         f"Use version ''9.0.0'' or higher.")
 else:


### PR DESCRIPTION
We want to use pre-released cupy 13.0.0a1, and this 'a1' string causes error in utils.imaging module. This branch has updates to adress this situation. 