### PR TITLE
#US4R-474: Fixed buffer overflow handling callback in case setSubsequence method was called.

### DIFF
--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.cpp
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.cpp
@@ -382,7 +382,7 @@ std::tuple<Us4RBuffer::Handle, FrameChannelMapping::Handle>
 ProbeAdapterImpl::setSubsequence(uint16_t start, uint16_t end, const std::optional<float> &sri) {
     // Cleanup.
     for(auto &us4oem: us4oems) {
-        us4oem->clearCallbacksPCIDMA();
+        us4oem->clearCallbacks();
     }
     // Determine start/stop OEMs op.
     uint16_t oemStart = logicalToPhysicalOp[start].first;

--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
@@ -135,7 +135,7 @@ public:
     MOCK_METHOD(uint32_t, getTxOffset, (), (override));
     MOCK_METHOD(uint32_t, getOemVersion, (), (override));
     MOCK_METHOD(void, setSubsequence, (uint16 start, uint16 end, bool syncMode, const std::optional<float> &sri), (override));
-    MOCK_METHOD(void, clearCallbacksPCIDMA, (), (override));
+    MOCK_METHOD(void, clearCallbacks, (), (override));
 };
 
 class AbstractProbeAdapterImplTest : public ::testing::Test {

--- a/arrus/core/devices/us4r/tests/MockIUs4OEM.h
+++ b/arrus/core/devices/us4r/tests/MockIUs4OEM.h
@@ -226,7 +226,7 @@ public:
     MOCK_METHOD(void, ResetSequencer, (), (override));
     MOCK_METHOD(float, SetHVPSSyncMeasurement, (uint16_t nSamples, float frequency), (override));
     MOCK_METHOD(HVPSMeasurements, GetHVPSMeasurements, (), (override));
-    MOCK_METHOD(void, ClearCallbacksPCIDMA, (), (override));
+    MOCK_METHOD(void, ClearCallbacks, (), (override));
     MOCK_METHOD(void, ClearTransferRXBufferToHost, (size_t firing), (override));
 };
 

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -894,8 +894,8 @@ void Us4OEMImpl::setSubsequence(uint16 start, uint16 end, bool syncMode, const s
     this->ius4oem->SetSubsequence(start, end, syncMode, timeToNextTrigger);
 }
 
-void Us4OEMImpl::clearCallbacksPCIDMA() {
-    this->ius4oem->ClearCallbacksPCIDMA();
+void Us4OEMImpl::clearCallbacks() {
+    this->ius4oem->ClearCallbacks();
 }
 
 }// namespace arrus::devices

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
@@ -162,7 +162,7 @@ public:
 
     void setSubsequence(uint16 start, uint16 end, bool syncMode, const std::optional<float> &sri) override;
 
-    void clearCallbacksPCIDMA() override;
+    void clearCallbacks() override;
 
 private:
     using Us4OEMBitMask = std::bitset<Us4OEMImpl::N_ADDR_CHANNELS>;

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImplBase.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImplBase.h
@@ -50,7 +50,7 @@ public:
 
     virtual void setSubsequence(uint16 start, uint16 end, bool syncMode, const std::optional<float> &sri) = 0;
 
-    virtual void clearCallbacksPCIDMA() = 0;
+    virtual void clearCallbacks() = 0;
 
 protected:
     explicit Us4OEMImplBase(const DeviceId &id) : Us4OEM(id) {}

--- a/docs/content/misc/release_notes.rst
+++ b/docs/content/misc/release_notes.rst
@@ -4,6 +4,12 @@ Release notes
 0.10.x
 -----
 
+0.10.1
+
+- core (C++):
+    - Fixed buffer overflow handling in case setSubsequence method was called #US4R-474.
+
+
 0.10.0
 
 - core (C++):


### PR DESCRIPTION
Resolves US4R-474.