### PR TITLE
#US4R-505: Set the proper start entry on the start/stop scheme (Us4R).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17.0)
 project(arrus LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 # Version
-set(PROJECT_VERSION 0.10.1)
+set(PROJECT_VERSION 0.10.2)
 set(ARRUS_PROJECT_VERSION "${PROJECT_VERSION}")
 string(TIMESTAMP CURRENT_YEAR "%Y")
 
@@ -82,7 +82,7 @@ set(ARRUS_DOCS_INSTALL_DIR docs)
 ################################################################################
 # Common dependencies
 ################################################################################
-find_package(Us4 0.11.1 EXACT REQUIRED US4OEM HV256 DBARLite DBARLitePcie)
+find_package(Us4 0.11.2 EXACT REQUIRED US4OEM HV256 DBARLite DBARLitePcie)
 find_package(Boost REQUIRED)
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Protobuf REQUIRED)

--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.cpp
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.cpp
@@ -302,7 +302,8 @@ ProbeAdapterImpl::setTxRxSequence(const std::vector<TxRxParameters> &seq, const 
 
     // Create the copy of FCM.
     fullSequenceFCM = outFcBuilder.build();
-    this->resetSequencerPointer = true;
+    // Move the sequence to the beginning.
+    this->oemSequencerStartEntry = 0;
     this->isCurrentlyTriggerSync = triggerSync;
     // Return the copy of FCM.
     return {us4RBufferBuilder.build(), outFcBuilder.build()};
@@ -316,7 +317,7 @@ void ProbeAdapterImpl::start() {
         // Reset tx subsystem pointers.
         us4oem->getIUs4oem()->EnableTransmit();
         // Reset sequencer pointers.
-        us4oem->enableSequencer(resetSequencerPointer);
+        us4oem->enableSequencer(oemSequencerStartEntry);
     }
     this->us4oems[0]->startTrigger();
 }
@@ -418,7 +419,7 @@ ProbeAdapterImpl::setSubsequence(uint16_t start, uint16_t end, const std::option
         oem->setSubsequence(oemStart, oemEnd, syncMode, sri);
     }
     // Do not reset sequencer pointer -- the next ptr was already handled by the setSubsequence method.
-    this->resetSequencerPointer = false;
+    this->oemSequencerStartEntry = oemStart;
     return {us4RBufferBuilder.build(), outFCMBuilder.build()};
 }
 

--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.h
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImpl.h
@@ -104,10 +104,10 @@ private:
     /** OEM number -> physical op -> next frame number (from the complete frame sequence) */
     std::vector<OpToNextFrameMapping> physicalOpToNextFrame;
     FrameChannelMappingImpl::Handle fullSequenceFCM;
-    /** Whether the sequencer pointer should be reset in the next call of the start method. NOTE: this property
-        will usually be set to false, except the case where the setting Seqeuncer pointer to 0 is not acceptable
+    /** Sequencer start pointer that should be set in the next call of the start method. NOTE: this property
+        will usually be set to 0, except the case where the setting Seqeuncer pointer to 0 is not acceptable
         e.g. after calling setSubsequence method with start > 0. */
-    bool resetSequencerPointer{true};
+    uint16 oemSequencerStartEntry{0};
     bool isCurrentlyTriggerSync{false};
 };
 }

--- a/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
+++ b/arrus/core/devices/us4r/probeadapter/ProbeAdapterImplTest.cpp
@@ -108,7 +108,7 @@ public:
     MOCK_METHOD(bool, isMaster, (), (override));
     MOCK_METHOD(void, setRxSettings, (const RxSettings &cfg), (override));
     MOCK_METHOD(Ius4OEMRawHandle, getIUs4oem, (), (override));
-    MOCK_METHOD(void, enableSequencer, (bool resetSequencerPointer), (override));
+    MOCK_METHOD(void, enableSequencer, (uint16 startEntry), (override));
     MOCK_METHOD(std::vector<uint8_t>, getChannelMapping, (), (override));
     MOCK_METHOD(float, getFPGATemperature, (), (override));
     MOCK_METHOD(void, setTestPattern, (Us4OEMImpl::RxTestPattern), (override));

--- a/arrus/core/devices/us4r/tests/MockIUs4OEM.h
+++ b/arrus/core/devices/us4r/tests/MockIUs4OEM.h
@@ -68,7 +68,7 @@ public:
     MOCK_METHOD(void, SetRxDelay,
             (const float delay, const unsigned short firing), (override));
     MOCK_METHOD(void, EnableTransmit, (), (override));
-    MOCK_METHOD(void, EnableSequencer, (bool txConfOnTrigger, bool resetSequencerPointer), (override));
+    MOCK_METHOD(void, EnableSequencer, (bool txConfOnTrigger, uint16_t startEntry), (override));
     MOCK_METHOD(void, SetRxChannelMapping,
             ( const std::vector<uint8_t> & mapping, const uint16_t rxMapId),
     (override));

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.cpp
@@ -627,13 +627,13 @@ void Us4OEMImpl::syncTrigger() { this->ius4oem->TriggerSync(); }
 
 Ius4OEMRawHandle Us4OEMImpl::getIUs4oem() { return ius4oem.get(); }
 
-void Us4OEMImpl::enableSequencer(bool resetSequencerPointer) {
+void Us4OEMImpl::enableSequencer(uint16_t startEntry) {
     bool txConfOnTrigger = false;
     switch (reprogrammingMode) {
     case Us4OEMSettings::ReprogrammingMode::SEQUENTIAL: txConfOnTrigger = false; break;
     case Us4OEMSettings::ReprogrammingMode::PARALLEL: txConfOnTrigger = true; break;
     }
-    this->ius4oem->EnableSequencer(txConfOnTrigger, resetSequencerPointer);
+    this->ius4oem->EnableSequencer(txConfOnTrigger, startEntry);
 }
 
 std::vector<uint8_t> Us4OEMImpl::getChannelMapping() { return channelMapping; }

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImpl.h
@@ -124,7 +124,7 @@ public:
 
     Ius4OEMRawHandle getIUs4oem() override;
 
-    void enableSequencer(bool resetSequencerPointer) override;
+    void enableSequencer(uint16_t startEntry) override;
 
     std::vector<uint8_t> getChannelMapping() override;
     void setRxSettings(const RxSettings &newSettings) override;

--- a/arrus/core/devices/us4r/us4oem/Us4OEMImplBase.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMImplBase.h
@@ -40,7 +40,7 @@ public:
     // TODO expose "registerUs4OEMOutputBuffer" function, keep this class hermetic
     virtual Ius4OEMRawHandle getIUs4oem() = 0;
 
-    virtual void enableSequencer(bool resetSequencerPointer = true) = 0;
+    virtual void enableSequencer(uint16_t startEntry = 0) = 0;
 
     virtual std::vector<uint8_t> getChannelMapping() = 0;
 


### PR DESCRIPTION
Resolves the issue described in the comment: https://us4us.myjetbrains.com/youtrack/issue/US4R-505/Application-hangs-and-lots-of-buffer-overflow-in-backend-log#focus=Comments-4-3844.0-0