### PR TITLE
#ARRUS-377: Fix paths in MATLAB code

### DIFF
--- a/api/matlab/arrus/Us4R.m
+++ b/api/matlab/arrus/Us4R.m
@@ -65,7 +65,7 @@ classdef Us4R < handle
                 error('Arrus requires Parallel Computing Toolbox and a supported GPU device');
             end
             % Add location of the CUDA kernels
-            addpath([fileparts(mfilename('fullpath')) '\mexcuda']);
+            addpath([fileparts(mfilename('fullpath')) '/mexcuda']);
 
             % Probe parameters
             probe = obj.us4r.getProbeModel;

--- a/api/matlab/examples/Us4R_control_bmodeDwi.m
+++ b/api/matlab/examples/Us4R_control_bmodeDwi.m
@@ -1,8 +1,8 @@
 % Example script for b-mode imaging using diverging waves and linear scanning
 
 %% Initialize the system
-addpath('..\');
-addpath('..\arrus');
+addpath('../');
+addpath('../arrus');
 
 % Make sure the configuration in the *.prototxt file is correct.
 us  = Us4R('configFile', 'us4r.prototxt');

--- a/api/matlab/examples/Us4R_control_bmodeLin.m
+++ b/api/matlab/examples/Us4R_control_bmodeLin.m
@@ -1,8 +1,8 @@
 % Example script for b-mode classical line-by-line imaging using focused waves and linear scanning
 
 %% Initialize the system
-addpath('..\');
-addpath('..\arrus');
+addpath('../');
+addpath('../arrus');
 
 % Make sure the configuration in the *.prototxt file is correct.
 us  = Us4R('configFile', 'us4r.prototxt');

--- a/api/matlab/examples/Us4R_control_bmodePwi.m
+++ b/api/matlab/examples/Us4R_control_bmodePwi.m
@@ -1,8 +1,8 @@
 % Example script for b-mode imaging using plane waves and angular scanning
 
 %% Initialize the system
-addpath('..\');
-addpath('..\arrus');
+addpath('../');
+addpath('../arrus');
 
 % Make sure the configuration in the *.prototxt file is correct.
 us  = Us4R('configFile', 'us4r.prototxt');

--- a/api/matlab/examples/Us4R_control_colorPwi.m
+++ b/api/matlab/examples/Us4R_control_colorPwi.m
@@ -1,8 +1,8 @@
 % Example script for b-mode & color doppler imaging (duplex) using plane waves
 
 %% Initialize the system
-addpath('..\');
-addpath('..\arrus');
+addpath('../');
+addpath('../arrus');
 
 % Make sure the configuration in the *.prototxt file is correct.
 us  = Us4R('configFile', 'us4r.prototxt');

--- a/api/matlab/examples/Us4R_control_rawRfPwi.m
+++ b/api/matlab/examples/Us4R_control_rawRfPwi.m
@@ -1,8 +1,8 @@
 % Example script for raw rf imaging when using plane waves and angular scanning
 
 %% Initialize the system
-addpath('..\');
-addpath('..\arrus');
+addpath('../');
+addpath('../arrus');
 
 % Make sure the configuration in the *.prototxt file is correct.
 us  = Us4R('configFile', 'us4r.prototxt');


### PR DESCRIPTION
Replace "\" with "/" in matlab paths