### PR TITLE
#US4R-525 Fix total time required for single TX/RX (minimum PRI)

### DIFF
--- a/arrus/core/devices/us4r/us4oem/Us4OEMDescriptorFactory.h
+++ b/arrus/core/devices/us4r/us4oem/Us4OEMDescriptorFactory.h
@@ -55,8 +55,8 @@ public:
                 version, // us4OEM version
                 32, // RX channels
                 20e-6f,  // min. RX time,
-                5e-6f, // RX time epsilon,
-                35e-6f, // TX parameters reprogramming time,
+                0e-6f, // RX time epsilon,
+                6e-6f, // TX parameters reprogramming time,
                 65e6f, // Sampling frequency [Hz]
                 1ull << 32u, // DDR memory size [B]
                 1ull << (14+12), // Max transfer size [B]


### PR DESCRIPTION
Changes due to increasing the TX pulser interface clock. It affects the TX pulsers reprogramming time (it is reduced). Now higher frame rates should be achievable. 