### PR TITLE
#ARRUS-365: rawReorg: returns zeros if input data too large

### DIFF
--- a/api/matlab/arrus/mexcuda/rawReorg.cu
+++ b/api/matlab/arrus/mexcuda/rawReorg.cu
@@ -15,15 +15,16 @@
 __global__ void rawReorgCplx( float2 *out, 
                               const short *in, 
                               const int *reorgMap, 
-                              const unsigned nSampOut )
+                              const unsigned nSampOut, 
+                              const int blockOffset)
 {
     __shared__ float2 tileShrd[OEM_N_CHAN][OEM_N_CHAN];
     
     size_t idx;
     
     // Input indices
-    int iChanIn = threadIdx.x;                           // gridSize[0] = 1 -> blockIdx.x = 0
-    int iSampIn = blockIdx.y * blockDim.y + threadIdx.y; // real and imag pair as a single sample
+    int iChanIn = threadIdx.x; // gridSize[0] = 1 -> blockIdx.x = 0
+    int iSampIn = (blockIdx.y + blockOffset) * blockDim.y + threadIdx.y; // real and imag pair as a single sample
     
     // Copy input to shared
     idx = iSampIn*2*OEM_N_CHAN + iChanIn;
@@ -34,7 +35,7 @@ __global__ void rawReorgCplx( float2 *out,
     __syncthreads();
     
     // Output indices
-    int iSampAux = blockIdx.y * blockDim.y + threadIdx.x;
+    int iSampAux = (blockIdx.y + blockOffset) * blockDim.y + threadIdx.x;
     int iChanAux = threadIdx.y;
     
     int iChunkIn = iSampAux / nSampOut;
@@ -57,7 +58,8 @@ __global__ void rawReorgCplx( float2 *out,
 __global__ void rawReorgReal( float *out, 
                               const short *in, 
                               const int *reorgMap, 
-                              const unsigned nSampOut )
+                              const unsigned nSampOut, 
+                              const int blockOffset)
 {
     __shared__ float tileShrd[OEM_N_CHAN][OEM_N_CHAN];
     
@@ -65,7 +67,7 @@ __global__ void rawReorgReal( float *out,
     
     // Input indices
     int iChanIn = threadIdx.x;
-    int iSampIn = blockIdx.y * blockDim.y + threadIdx.y;
+    int iSampIn = (blockIdx.y + blockOffset) * blockDim.y + threadIdx.y;
     
     // Copy input to shared
     idx = iSampIn*OEM_N_CHAN + iChanIn;
@@ -75,7 +77,7 @@ __global__ void rawReorgReal( float *out,
     __syncthreads();
     
     // Output indices
-    int iSampAux = blockIdx.y * blockDim.y + threadIdx.x;
+    int iSampAux = (blockIdx.y + blockOffset) * blockDim.y + threadIdx.x;
     int iChanAux = threadIdx.y;
     
     int iChunkIn = iSampAux / nSampOut;
@@ -156,8 +158,17 @@ void mexFunction(int nlhs, mxArray * plhs[],
         out = mxGPUCreateGPUArray(nDimOut, dimOut, mxSINGLE_CLASS, mxCOMPLEX, MX_GPU_INITIALIZE_VALUES);
         float2 * dev_out = static_cast<float2 *>(mxGPUGetData(out));
         
-        dim3 blocksPerGrid = {1, nSampIn / 2 / threadsPerBlock.y, 1};
-        rawReorgCplx<<<blocksPerGrid, threadsPerBlock>>>( dev_out, dev_in, dev_reorgMap, nSampOut);
+        /* Kernel in loop - due to blocksPerGrid limit */
+        int nBlock = nSampIn / 2 / threadsPerBlock.y;
+        int nBlockPerPart = (nBlock <= 65535) ? nBlock : 65535;
+        int nPart = (nBlock+nBlockPerPart-1)/nBlockPerPart;
+        for (int iPart=0; iPart<nPart; iPart++) {
+            
+            unsigned int nBlockInThisPart = (iPart<(nPart-1)) ? nBlockPerPart : (nBlock-iPart*nBlockPerPart);
+            
+            dim3 blocksPerGrid = {1, nBlockInThisPart, 1};
+            rawReorgCplx<<<blocksPerGrid, threadsPerBlock>>>( dev_out, dev_in, dev_reorgMap, nSampOut, iPart*nBlockPerPart);
+        }
     }
     else {
         unsigned int nSampOut = nSampIn / nChunkIn;
@@ -168,8 +179,17 @@ void mexFunction(int nlhs, mxArray * plhs[],
         out = mxGPUCreateGPUArray(nDimOut, dimOut, mxSINGLE_CLASS, mxREAL, MX_GPU_INITIALIZE_VALUES);
         float * dev_out = static_cast<float *>(mxGPUGetData(out));
         
-        dim3 blocksPerGrid = {1, nSampIn / threadsPerBlock.y, 1};
-        rawReorgReal<<<blocksPerGrid, threadsPerBlock>>>( dev_out, dev_in, dev_reorgMap, nSampOut);
+        /* Kernel in loop - due to blocksPerGrid limit */
+        int nBlock = nSampIn / threadsPerBlock.y;
+        int nBlockPerPart = (nBlock <= 65535) ? nBlock : 65535;
+        int nPart = (nBlock+nBlockPerPart-1)/nBlockPerPart;
+        for (int iPart=0; iPart<nPart; iPart++) {
+            
+            unsigned int nBlockInThisPart = (iPart<(nPart-1)) ? nBlockPerPart : (nBlock-iPart*nBlockPerPart);
+
+            dim3 blocksPerGrid = {1, nBlockInThisPart, 1};
+            rawReorgReal<<<blocksPerGrid, threadsPerBlock>>>( dev_out, dev_in, dev_reorgMap, nSampOut, iPart*nBlockPerPart);
+        }
     }
     
     /* Wrap the output */


### PR DESCRIPTION
Bug fix in calling rawReorg kernel (blockIdx.y must be < 64k)