### PR TITLE
Add GPU prototxt setting to enable customisation of MemoryPool Usage and RAM Limit for ProcessingRunner

### DIFF
--- a/api/python/wrappers/core.i
+++ b/api/python/wrappers/core.i
@@ -130,6 +130,26 @@ namespace std {
     }
 %}
 
+%typemap(out) std::optional<float>* %{
+    if($1 && $1->has_value()) {
+        $result = PyFloat_FromDouble($1->value());
+    }
+    else {
+        $result = Py_None;
+        Py_INCREF(Py_None);
+    }
+%}
+
+%typemap(out) const std::optional<float>& %{
+    if($1 && $1->has_value()) {
+        $result = PyFloat_FromDouble($1->value());
+    }
+    else {
+        $result = Py_None;
+        Py_INCREF(Py_None);
+    }
+%}
+
 %typemap(in) std::optional<long long> %{
     if($input == Py_None) {
         $1 = std::optional<long long>();
@@ -156,8 +176,6 @@ namespace std {
         Py_INCREF(Py_None);
     }
 %}
-
-
 
 %module(directors="1") core
 
@@ -558,6 +576,7 @@ void Arrus2dArrayVectorPushBack(
 // Turn on globally value wrappers
 %feature("valuewrapper");
 %{
+#include "arrus/core/api/devices/us4r/GpuSettings.h"
 #include "arrus/core/api/devices/us4r/WatchdogSettings.h"
 #include "arrus/core/api/devices/us4r/RxSettings.h"
 #include "arrus/core/api/devices/us4r/Us4OEMSettings.h"
@@ -575,6 +594,7 @@ using namespace ::arrus::devices;
 %};
 
 %include "arrus/core/api/devices/us4r/WatchdogSettings.h";
+%include "arrus/core/api/devices/us4r/GpuSettings.h";
 %include "arrus/core/api/devices/us4r/RxSettings.h";
 %include "arrus/core/api/devices/us4r/Us4OEMSettings.h";
 %ignore operator<<(std::ostream &os, const ProbeAdapterModelId &id);

--- a/arrus/core/CMakeLists.txt
+++ b/arrus/core/CMakeLists.txt
@@ -26,6 +26,7 @@ protobuf_generate_cpp(PROTO_SRC PROTO_HDRS
     io/proto/devices/us4r/Bitstream.proto
     io/proto/devices/us4r/Us4RTxRxLimits.proto
     io/proto/devices/us4r/WatchdogSettings.proto
+    io/proto/devices/us4r/GpuSettings.proto
 )
 ################################################################################
 # Target
@@ -204,8 +205,9 @@ set(SRC_FILES
     api/devices/us4r/Us4RTxRxLimits.h
     devices/us4r/TxTimeoutRegister.h
     devices/us4r/Us4RSubsequence.h
-    devices/us4r/types.h
+    devices/us4r/types.h    
     api/devices/us4r/WatchdogSettings.h
+    api/devices/us4r/GpuSettings.h
     api/devices/probe/Lens.h
     api/devices/probe/MatchingLayer.h
     api/version.h
@@ -243,6 +245,18 @@ target_include_directories(${TARGET_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+# Add CUDA include directories if CUDA is available
+if(CUDAToolkit_FOUND)
+    target_include_directories(${TARGET_NAME}
+        PRIVATE
+        ${CUDAToolkit_INCLUDE_DIRS}
+    )
+    target_compile_definitions(${TARGET_NAME}
+        PRIVATE
+        CUDA_AVAILABLE
+    )
+endif()
+
 ################################################################################
 # Dependencies
 ################################################################################
@@ -261,6 +275,14 @@ target_link_libraries(${TARGET_NAME}
     Microsoft.GSL::GSL
     ${ARRUS_OS_DEPS}
 )
+
+# Add CUDA libraries if CUDA is available
+if(CUDAToolkit_FOUND)
+    target_link_libraries(${TARGET_NAME}
+        PRIVATE
+        CUDA::cudart
+    )
+endif()
 ################################################################################
 # Target compile options
 ################################################################################

--- a/arrus/core/api/devices/us4r/GpuSettings.h
+++ b/arrus/core/api/devices/us4r/GpuSettings.h
@@ -1,0 +1,62 @@
+#ifndef ARRUS_CORE_API_DEVICES_US4R_GPUSETTINGS_H
+#define ARRUS_CORE_API_DEVICES_US4R_GPUSETTINGS_H
+
+#include <string>
+#include <optional>
+
+namespace arrus::devices {
+
+class GpuSettings {
+public:
+    explicit GpuSettings(std::optional<float> memoryLimitPercentage = std::nullopt, bool useMemoryPool = true)
+        : memoryLimitPercentage(std::move(memoryLimitPercentage)), useMemoryPool(useMemoryPool) {}
+
+    /**
+     * Returns the GPU memory limit as a percentage of total VRAM (e.g., 0.5 = 50%).
+     * 
+     * @return Memory limit percentage, or std::nullopt if no limit is set
+     */
+    const std::optional<float>& getMemoryLimitPercentage() const { return memoryLimitPercentage; }
+
+    /**
+     * Sets the GPU memory limit as a percentage of total VRAM.
+     * 
+     * @param memoryLimitPercentage Memory limit as a percentage (e.g., 0.5 = 50%)
+     */
+    void setMemoryLimitPercentage(std::optional<float> memoryLimitPercentage) {
+        this->memoryLimitPercentage = std::move(memoryLimitPercentage);
+    }
+
+    /**
+     * Returns whether to use GPU memory pool.
+     * 
+     * @return True if memory pool should be used, false otherwise
+     */
+    bool getUseMemoryPool() const { return useMemoryPool; }
+
+    /**
+     * Sets whether to use GPU memory pool.
+     * 
+     * @param useMemoryPool True to use memory pool, false otherwise
+     */
+    void setUseMemoryPool(bool useMemoryPool) {
+        this->useMemoryPool = useMemoryPool;
+    }
+
+    /**
+     * Creates default GPU settings (no memory limit, memory pool enabled).
+     * 
+     * @return Default GPU settings
+     */
+    static GpuSettings defaultSettings() {
+        return GpuSettings();
+    }
+
+private:
+    std::optional<float> memoryLimitPercentage;
+    bool useMemoryPool;
+};
+
+}
+
+#endif //ARRUS_CORE_API_DEVICES_US4R_GPUSETTINGS_H 

--- a/arrus/core/api/devices/us4r/Us4RSettings.h
+++ b/arrus/core/api/devices/us4r/Us4RSettings.h
@@ -15,6 +15,7 @@
 #include "arrus/core/api/devices/us4r/DigitalBackplaneSettings.h"
 #include "arrus/core/api/devices/us4r/Bitstream.h"
 #include "arrus/core/api/devices/us4r/WatchdogSettings.h"
+#include "arrus/core/api/devices/us4r/GpuSettings.h"
 
 namespace arrus::devices {
 
@@ -36,7 +37,8 @@ public:
         std::optional<DigitalBackplaneSettings> digitalBackplaneSettings = std::nullopt,
         std::vector<Bitstream> bitstreams = std::vector<Bitstream>(),
         std::optional<Us4RTxRxLimits> limits = std::nullopt,
-        WatchdogSettings watchdogSettings = WatchdogSettings::defaultSettings()
+        WatchdogSettings watchdogSettings = WatchdogSettings::defaultSettings(),
+        GpuSettings gpuSettings = GpuSettings::defaultSettings()
     ) : probeAdapterSettings(std::move(probeAdapterSettings)),
           probeSettings(std::move(probeSettings)),
           rxSettings(std::move(rxSettings)),
@@ -50,7 +52,8 @@ public:
           digitalBackplaneSettings(std::move(digitalBackplaneSettings)),
           bitstreams(std::move(bitstreams)),
           limits(std::move(limits)),
-          watchdogSettings(std::move(watchdogSettings))
+          watchdogSettings(std::move(watchdogSettings)),
+          gpuSettings(std::move(gpuSettings))
     {}
 
     Us4RSettings(
@@ -67,7 +70,8 @@ public:
         std::optional<DigitalBackplaneSettings> digitalBackplaneSettings = std::nullopt,
         std::vector<Bitstream> bitstreams = std::vector<Bitstream>(),
         std::optional<Us4RTxRxLimits> limits = std::nullopt,
-        WatchdogSettings watchdogSettings = WatchdogSettings::defaultSettings()
+        WatchdogSettings watchdogSettings = WatchdogSettings::defaultSettings(),
+        GpuSettings gpuSettings = GpuSettings::defaultSettings()
         ) : Us4RSettings(
                 std::move(probeAdapterSettings),
                 std::vector<ProbeSettings>{std::move(probeSettings)},
@@ -82,7 +86,8 @@ public:
                 std::move(digitalBackplaneSettings),
                 std::move(bitstreams),
                 std::move(limits),
-                std::move(watchdogSettings)
+                std::move(watchdogSettings),
+                std::move(gpuSettings)
         )
     {}
 
@@ -177,6 +182,8 @@ public:
 
     const WatchdogSettings &getWatchdogSettings() const { return watchdogSettings; }
 
+    const GpuSettings &getGpuSettings() const { return gpuSettings; }
+
 private:
     /* A list of settings for Us4OEMs.
      * First element configures Us4OEM:0, second: Us4OEM:1, etc. */
@@ -229,6 +236,8 @@ private:
      std::optional<Us4RTxRxLimits> limits{std::nullopt};
      /** OEM watchdog settings */
      WatchdogSettings watchdogSettings{1.0f, 1.1f, 1.0f};
+     /** GPU settings */
+     GpuSettings gpuSettings;
 };
 
 }

--- a/arrus/core/io/proto/devices/us4r/GpuSettings.proto
+++ b/arrus/core/io/proto/devices/us4r/GpuSettings.proto
@@ -1,0 +1,10 @@
+syntax  = "proto3";
+
+package arrus.proto;
+
+message GpuSettings {
+  // Memory limit as a percentage of total VRAM (e.g., 0.5 = 50% of VRAM)
+  float memory_limit_percentage = 1;
+  // Whether to use GPU memory pool for memory management
+  bool use_memory_pool = 2;
+} 

--- a/arrus/core/io/proto/devices/us4r/Us4RSettings.proto
+++ b/arrus/core/io/proto/devices/us4r/Us4RSettings.proto
@@ -12,6 +12,7 @@ import "io/proto/devices/us4r/DigitalBackplaneSettings.proto";
 import "io/proto/devices/us4r/Bitstream.proto";
 import "io/proto/devices/us4r/Us4RTxRxLimits.proto";
 import "io/proto/devices/us4r/WatchdogSettings.proto";
+import "io/proto/devices/us4r/GpuSettings.proto";
 
 message Us4RSettings {
   // Only one of the following is available: (probe, adapter, rxsettings)
@@ -48,4 +49,5 @@ message Us4RSettings {
   repeated Bitstream bitstreams = 16;
   Us4RTxRxLimits tx_rx_limits = 17;
   WatchdogSettings watchdog = 18;
+  GpuSettings gpu = 19;
 }

--- a/arrus/core/io/settings.cpp
+++ b/arrus/core/io/settings.cpp
@@ -541,6 +541,13 @@ Us4RSettings readUs4RSettings(const proto::Us4RSettings &us4r, const SettingsDic
             watchdog = WatchdogSettings::disabled();
         }
     }
+    
+    GpuSettings gpu = GpuSettings::defaultSettings();    
+    if(us4r.gpu().memory_limit_percentage() > 0.0f) {
+        gpu = GpuSettings(us4r.gpu().memory_limit_percentage(), us4r.gpu().use_memory_pool());
+    } else {
+        gpu = GpuSettings(std::nullopt, us4r.gpu().use_memory_pool());
+    }    
 
     ProbeAdapterSettings adapterSettings = readOrGetAdapterSettings(us4r, dictionary);
     std::vector<ProbeSettings> probeSettings =
@@ -566,7 +573,8 @@ Us4RSettings readUs4RSettings(const proto::Us4RSettings &us4r, const SettingsDic
             digitalBackplaneSettings,
             bitstreams,
             limits,
-            watchdog
+            watchdog,
+            gpu
     };
 }
 Us4OEMSettings::ReprogrammingMode convertToReprogrammingMode(proto::Us4OEMSettings_ReprogrammingMode mode) {

--- a/arrus/core/io/test-data/us4r.prototxt
+++ b/arrus/core/io/test-data/us4r.prototxt
@@ -56,6 +56,11 @@ us4r: {
         oem_threshold1: 2.0
         host_threshold: 3.0
     }
+
+    gpu: {
+        memory_limit_percentage: 0.5
+        use_memory_pool: true
+    }
 }
 
 

--- a/arrus/core/io/validators/GpuSettingsProtoValidator.h
+++ b/arrus/core/io/validators/GpuSettingsProtoValidator.h
@@ -1,0 +1,58 @@
+#ifndef ARRUS_CORE_IO_VALIDATORS_GPUSETTINGSPROTOVALIDATOR_H
+#define ARRUS_CORE_IO_VALIDATORS_GPUSETTINGSPROTOVALIDATOR_H
+
+#include "arrus/common/compiler.h"
+#include "arrus/core/common/validation.h"
+
+COMPILER_PUSH_DIAGNOSTIC_STATE
+COMPILER_DISABLE_MSVC_WARNINGS(4127)
+
+#include "io/proto/devices/us4r/GpuSettings.pb.h"
+
+COMPILER_POP_DIAGNOSTIC_STATE
+
+namespace arrus::io {
+
+class GpuSettingsProtoValidator : public Validator<arrus::proto::GpuSettings> {
+public:
+    explicit GpuSettingsProtoValidator(const std::string &name) : Validator(name) {}
+
+    void validate(const arrus::proto::GpuSettings &obj) override {
+        // Memory limit percentage is optional, but if provided, it should be a valid percentage
+        if (obj.memory_limit_percentage() > 0.0f) {
+            validateMemoryLimitPercentage(obj.memory_limit_percentage());
+        }
+        
+        // Validate use_memory_pool field (boolean validation is implicit)
+        // The field is optional and defaults to false in protobuf
+        // No additional validation needed for boolean fields
+    }
+
+private:
+    void validateMemoryLimitPercentage(float memoryLimitPercentage) {
+        // Check if the memory limit percentage is within valid range (0.0 to 1.0)
+        if (memoryLimitPercentage < 0.0f || memoryLimitPercentage > 1.0f) {
+            expectTrue("memory_limit_percentage", false, 
+                      "Memory limit percentage must be between 0.0 and 1.0. Got: " + std::to_string(memoryLimitPercentage));
+            return;
+        }
+        
+        // Check if the percentage is reasonable (not too small)
+        if (memoryLimitPercentage < 0.01f) {
+            expectTrue("memory_limit_percentage", false, 
+                      "Memory limit percentage is too small. Minimum allowed is 0.01 (1%). Got: " + std::to_string(memoryLimitPercentage));
+            return;
+        }
+        
+        // Check if the percentage is reasonable (not too large)
+        if (memoryLimitPercentage > 0.95f) {
+            expectTrue("memory_limit_percentage", false, 
+                      "Memory limit percentage is too large. Maximum allowed is 0.95 (95%). Got: " + std::to_string(memoryLimitPercentage));
+            return;
+        }
+    }
+};
+
+}
+
+#endif //ARRUS_CORE_IO_VALIDATORS_GPUSETTINGSPROTOVALIDATOR_H 

--- a/arrus/core/io/validators/Us4RSettingsProtoValidator.h
+++ b/arrus/core/io/validators/Us4RSettingsProtoValidator.h
@@ -8,6 +8,8 @@
 #include "arrus/core/io/validators/ProbeAdapterModelProtoValidator.h"
 #include "arrus/core/io/validators/ProbeToAdapterConnectionProtoValidator.h"
 #include "arrus/core/io/validators/RxSettingsProtoValidator.h"
+#include "arrus/core/io/validators/GpuSettingsProtoValidator.h"
+
 
 COMPILER_PUSH_DIAGNOSTIC_STATE
 COMPILER_DISABLE_MSVC_WARNINGS(4127)
@@ -72,6 +74,11 @@ class Us4RSettingsProtoValidator : public Validator<arrus::proto::Us4RSettings> 
         RxSettingsProtoValidator rxSettingsValidator("rx_settings");
         rxSettingsValidator.validate(us4r.rx_settings());
         copyErrorsFrom(rxSettingsValidator);
+
+        // Validate GPU settings if present
+        GpuSettingsProtoValidator gpuSettingsValidator("gpu");
+        gpuSettingsValidator.validate(us4r.gpu());
+        copyErrorsFrom(gpuSettingsValidator);        
     }
 
     bool hasProbe(const arrus::proto::Us4RSettings &us4r) const {

--- a/docs/content/user_guide.python.rst
+++ b/docs/content/user_guide.python.rst
@@ -480,6 +480,25 @@ You can also turn off the watchdog mechanism by setting the ``enabled`` field to
 
     watchdog: {enabled: false}
 
+GPU Settings
+............
+
+The GPU settings are used to configure the GPU memory limit and the use of the memory pool, as used by the ProcessingRunner class within
+the imaging pipeline. Typical values are:
+
+::  gpu: {
+        memory_limit_percentage: 0.5
+        use_memory_pool: true
+    }
+
+The ``memory_limit_percentage`` is the percentage of the GPU memory that should be used by the memory pool. Values between 0.01 and 0.95 are allowed.
+The ``use_memory_pool`` is a boolean flag that indicates whether to use the memory pool if set to ``false`` then the memory pool is not used.
+
+When changing schemes, GPU RAM usage can rise as although memory has been allocated for the previous scheme, it is not released but is cached as part of the session.
+If other GPU processes are on the device this can lead to an out-of-memory issue even though there is enough memory for all processes on the hardware.
+The ``use_memory_pool`` flag can be used to disable the memory pool and force the memory to be released after each scheme.
+
+More information on cupy memory management can be found `here <https://docs.cupy.dev/en/stable/user_guide/memory.html>`_.
 
 Trigger source (TRIG IN/OUT)
 ............................


### PR DESCRIPTION
When using arrus with other GPU applications on a device, the use of the default mempool can lead to the arrus instances taking more and more memory if set_scheme is used over and over. 

In cases where other processes are using the GPU, this cause issues with memory management as cupy seems to avoid freeing up all the GPU memory for other processes. 

While env_var variables can be used to limit all cupy processes on the device, this PR adds a couple of params to the ARRUS prototxt so that ultrasound imaging alone can be memory managed by the user without having to do global adjustment of memory limits.

Another approach would be to remove memory pooling entirely but I think this approach should provide flexibility for all development, providing the ability to add it on/off and also set a hard limit for the GPU memory when using ARRUS.

This was tested and built on arrus v0.11.0 and successfully ran by monitoring changes to different schemes running different doppler and bmode schemes then monitoring the GPU usage by using `nvtop`