### PR TITLE
#ARRUS-483: Various small upgrades / bug fixes (MATLAB)

### DIFF
--- a/api/matlab/arrus/CustomTxRxSequence.m
+++ b/api/matlab/arrus/CustomTxRxSequence.m
@@ -57,7 +57,7 @@ classdef CustomTxRxSequence
         txFocus (1,:) {mustBeNonNan, mustBeReal}
         txAngle (1,:) {mustBeFinite, mustBeReal}
         speedOfSound (1,1) {mustBeProperNumber}
-        txVoltage  (1,1) {mustBeNonnegative} = 0;
+        txVoltage  (:,:) {mustBeNonnegative} = 0;
         txVoltageId (1,:) = 1
         txFrequency (1,:) = []
         txNPeriods (1,:) = []
@@ -139,8 +139,8 @@ classdef CustomTxRxSequence
             if ~ismatrix(obj.txVoltage) || (~isscalar(obj.txVoltage) && ~all(size(obj.txVoltage)==[2 2]))
                 error("ARRUS:IllegalArgument", 'txVoltage must be scalar or 2x2 array');
             end
-            if ~isscalar(obj.txVoltage) && any(obj.txVoltage(1,:) <= obj.txVoltage(2,:))
-                error("ARRUS:IllegalArgument", 'txVoltage(1,:) must be higher than txVoltage(2,:)');
+            if ~isscalar(obj.txVoltage) && any(obj.txVoltage(1,:) >= obj.txVoltage(2,:))
+                error("ARRUS:IllegalArgument", 'txVoltage(2,:) must be higher than txVoltage(1,:)');
             end
             if isempty(obj.txWaveform)
                 if isempty(obj.txInvert)

--- a/api/matlab/arrus/CustomTxRxSequence.m
+++ b/api/matlab/arrus/CustomTxRxSequence.m
@@ -102,7 +102,7 @@ classdef CustomTxRxSequence
                       "workMode must be one of the following: MANUAL, HOST, SYNC, or ASYNC.");
             end
 
-            if ~xor(isempty(obj.txWaveform), isempty(obj.txFrequency) && isempty(obj.txNPeriods) && isempty(obj.txInvert))
+            if ~xor(isempty(obj.txWaveform), isempty(obj.txFrequency) && isempty(obj.txNPeriods) && ~obj.txInvert)
                 error("ARRUS:IllegalArgument", ...
                 "Exactly one of the following should be provided: txWaveform or (txFrequency, txNPeriods, and txInvert)");
             end
@@ -142,6 +142,8 @@ classdef CustomTxRxSequence
             if ~isscalar(obj.txVoltage) && any(obj.txVoltage(1,:) >= obj.txVoltage(2,:))
                 error("ARRUS:IllegalArgument", 'txVoltage(2,:) must be higher than txVoltage(1,:)');
             end
+
+            %% Pulse validation
             if isempty(obj.txWaveform)
                 if isempty(obj.txInvert)
                     obj.txInvert = false;
@@ -151,6 +153,8 @@ classdef CustomTxRxSequence
                 obj.txNPeriods          = mustBeProperLength(obj.txNPeriods,nTx);
                 obj.txInvert            = mustBeProperLength(obj.txInvert,nTx);
                 obj.txInvert            = double(obj.txInvert);
+            else
+                obj.txInvert            = [];
             end
         end
     end

--- a/api/matlab/arrus/CustomTxRxSequence.m
+++ b/api/matlab/arrus/CustomTxRxSequence.m
@@ -58,7 +58,7 @@ classdef CustomTxRxSequence
         txAngle (1,:) {mustBeFinite, mustBeReal}
         speedOfSound (1,1) {mustBeProperNumber}
         txVoltage  (:,:) {mustBeNonnegative} = 0;
-        txVoltageId (1,:) = 1
+        txVoltageId (1,:) = 2
         txFrequency (1,:) = []
         txNPeriods (1,:) = []
         rxDepthRange (1,:) {mustBeProperNumber}

--- a/api/matlab/arrus/Us4R.m
+++ b/api/matlab/arrus/Us4R.m
@@ -883,7 +883,14 @@ classdef Us4R < handle
                     end
                 end
             end
-
+            
+            % txWaveform is not supported here yet
+            for iSeq=1:nSeq
+                if ~isempty(obj.seq.txWaveform)
+                    error("mergeSequences: txWaveform cannot be used in multi-sequence approach");
+                end
+            end
+            
             % Some of the parameters not included in the above validation
             % must be defined in a "one or the other" mode. Checking if the
             % same fields are empty is enough.
@@ -1331,7 +1338,7 @@ classdef Us4R < handle
             end
 
         end
-        
+
         function calcTxRxApMask(obj)
             % calcTxRxApMask appends the following fields to the in/out obj:
             % obj.seq.txApOrig      - [element] (1 x nTx) number of probe element being the origin of the tx aperture
@@ -1416,7 +1423,7 @@ classdef Us4R < handle
             obj.seq.txDelCent	= txDelCent;
 
         end
-        
+
         function programHW(obj)
             
             import arrus.ops.us4r.*;
@@ -1474,14 +1481,13 @@ classdef Us4R < handle
             obj.us4r.setTgcCurve(obj.seq.tgcPoints, obj.seq.tgcCurve, 0, 1);
         end
 
-        % txWaveform must be handled properly here!!!
         function selSubSeq(obj, seqId, sri)
             
             % Copy selected part of sequence to subsequence
             seqFieldsToCopy = { 'rxApSize', 'c', 'txVoltage', 'dRange', 'startSample', 'nSamp', ...
                                 'hwDdcEnable', 'dec', 'nRep', 'txPri', 'tgcStart', 'tgcSlope', ...
                                 'workMode', 'sri', 'bufferSize', 'fpgaDec', 'ddcFirCoeff', ...
-                                'rxSampFreq', 'tgcPoints', 'tgcCurve', 'txDelCent'};
+                                'rxSampFreq', 'tgcPoints', 'tgcCurve', 'txDelCent', 'txWaveform'};
             for iFld=1:numel(seqFieldsToCopy)
                 obj.subSeq.(seqFieldsToCopy{iFld}) = obj.seq.(seqFieldsToCopy{iFld});
             end

--- a/api/matlab/arrus/Us4R.m
+++ b/api/matlab/arrus/Us4R.m
@@ -1499,8 +1499,12 @@ classdef Us4R < handle
                                 'txApMask', 'rxApMask', 'rxApPadding', 'txDel', ...
                                 'nSampOmit', 'initDel'};
             for iFld=1:numel(seqFieldsToExtr)
-                obj.subSeq.(seqFieldsToExtr{iFld}) = obj.seq.(seqFieldsToExtr{iFld})(:,obj.seq.seqLim(seqId,1) ...
-                                                                                     : obj.seq.seqLim(seqId,2));
+                if isempty(obj.seq.(seqFieldsToExtr{iFld})) || isscalar(obj.seq.(seqFieldsToExtr{iFld}))
+                    obj.subSeq.(seqFieldsToExtr{iFld}) = obj.seq.(seqFieldsToExtr{iFld});
+                else
+                    obj.subSeq.(seqFieldsToExtr{iFld}) = obj.seq.(seqFieldsToExtr{iFld})(:,obj.seq.seqLim(seqId,1) ...
+                                                                                         : obj.seq.seqLim(seqId,2));
+                end
             end
 
             obj.subSeq.nTx = obj.seq.seqLim(seqId,2) - obj.seq.seqLim(seqId,1) + 1;

--- a/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
+++ b/api/matlab/wrappers/devices/us4r/Us4RClassImpl.h
@@ -139,8 +139,13 @@ public:
     }
 
     void setActiveTermination(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {
-        uint16 impedance = inputs[0][0];
-        get(obj)->setActiveTermination(impedance);
+        if(inputs[0].isEmpty()) {
+            get(obj)->setActiveTermination(std::nullopt);
+        }
+        else {
+            uint16 impedance = inputs[0][0];
+            get(obj)->setActiveTermination(impedance);
+        }
     }
 
     void setLnaGain(MatlabObjectHandle obj, MatlabOutputArgs &outputs, MatlabInputArgs &inputs) {


### PR DESCRIPTION
A set of small changes in ARRUS Matlab:
- Exposed an option to disable the active termination
- Fixed the problem with txVoltage levels (which is default, which must be higher)
- Fixed support for txWaveforms
- Modified pulse validation when txWaveform is used