### PR TITLE
#M_US4R-42: Fixed memory leak in the UniqueHandle class implementation. 

### DIFF
--- a/arrus/core/api/common/UniqueHandle.h
+++ b/arrus/core/api/common/UniqueHandle.h
@@ -24,6 +24,8 @@ public:
 
     UniqueHandle(nullptr_t v = nullptr): ptr{v} {}
 
+    ~UniqueHandle() { delete ptr; }
+
     UniqueHandle(const UniqueHandle &other) {
         if(other) {
             ptr = new T{*other};


### PR DESCRIPTION
Closes #407 